### PR TITLE
Adds "How to participate" From The Hacktoberfest Announcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ Questions? Look for existing issues in this repo first. Otherwise, create a new 
 
 Thanks!
 
+# How to participate
+1. **Find a project that looks interesting**. You can browse all our of repos on https://opensource.microsoft.com and filter by keyword, trending, stars, forks, tags, and more.
+2. Perhaps you already have a great idea for improving the project. If not, **browse the list of open issues**. My favorite tip: look for issues labeled help-wanted or good-first-issue.
+3. **Make a Pull Request** to improve the project’s code or documentation.
+4. **[Important]** Complete [this form](https://aka.ms/hacktoberfestshirt) to make sure we enter you in the challenge and register your participation. We’ll send instructions for receiving your shirt after Hacktoberfest ends.
+
+…that’s it!
 
 
 # Contributing


### PR DESCRIPTION
Adds the "How to participate" table from the "Join our #Hacktoberfest 2018 celebration!" by Bernd Verst blog post on the Microsoft + Open Source blog, allowing for much easier access to first-timers to see what to do. Perhaps most importantly of all, **it provides the link to the free t-shirt directly!**

Table from: https://open.microsoft.com/2018/09/30/join-hacktoberfest-2018-celebration-microsoft/